### PR TITLE
Client: make client embedded and expose teamID.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -172,8 +172,8 @@
 [[projects]]
   name = "github.com/manifoldco/go-manifold"
   packages = [".","errors","idtype"]
-  revision = "0157de683d3704492c35e6501f8497ebb7d5e69d"
-  version = "v0.8.4"
+  revision = "862735f1fd67b174923ceb5bee05f6f60b2f4bbc"
+  version = "v0.8.5"
 
 [[projects]]
   branch = "master"
@@ -203,7 +203,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ed25519","ed25519/internal/edwards25519","pbkdf2","scrypt"]
-  revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
+  revision = "bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8"
 
 [[projects]]
   branch = "master"
@@ -215,7 +215,7 @@
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
-  revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
+  revision = "7d4e23b25beca3bc3b804ab134f0b12b4ca909d1"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -263,7 +263,7 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "61b46af70dfed79c6d24530cd23b41440a7f22a5"
+  revision = "d52097ab4580a8f654862188cd66db48e87f62a3"
 
 [solve-meta]
   analyzer-name = "dep"


### PR DESCRIPTION
We want to be able to do other API calls as well, so wrap up the client and
expose the fetched TeamID.