### PR TITLE
Client: fix team check.

### DIFF
--- a/helpers/client/client.go
+++ b/helpers/client/client.go
@@ -309,7 +309,7 @@ func (c *Client) setCachedProjectID(label string, id *manifold.ID) {
 }
 
 func (c *Client) ensureTeamID() error {
-	if c.team == nil {
+	if c.team == nil || *c.team == "" {
 		// no team specified, skip it
 		return nil
 	}


### PR DESCRIPTION
A pointer to an empty string is still a valid pointer, so add a check to
see if the team is empty or not.