### PR TITLE
Credentials: add decoder option.

### DIFF
--- a/primitives/credential.go
+++ b/primitives/credential.go
@@ -5,9 +5,10 @@ import "github.com/manifoldco/go-manifold/integrations/primitives"
 // CredentialSpec represents the specification that is required to filter out
 // specific credentials in the Resource spec.
 type CredentialSpec struct {
-	Key     string `json:"key"`
-	Name    string `json:"name,omitempty"`
-	Default string `json:"default,omitempty"`
+	Key      string `json:"key"`
+	Name     string `json:"name,omitempty"`
+	Default  string `json:"default,omitempty"`
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // ManifoldPrimitive converts the CredentialSpec to a manifold project integration


### PR DESCRIPTION
Multiline secrets will be encoded as base64. This option allows us to
decode them when injecting into a kubernetes secret so they're not
double encoded in a k8s secret.