### PR TITLE
Separate namespace + `-credentials` suffix removal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Put the default controller deployment in it's own namespace.
+- Removed the `-credentials` suffix from the generated secrets.
+
 ## [0.0.4] - 2017-11-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added the posibility to specify the secret type that needs to be generated for a resource.
+
 ### Changed
 
 - Put the default controller deployment in it's own namespace.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ vendor: Gopkg.lock
 deepcopy-gen:
 	go get -u k8s.io/code-generator/cmd/deepcopy-gen
 
+generated: primitives/zz_generated.go
+
 primitives/zz_generated.go: deepcopy-gen $(wildcard primitives,*.go)
 	deepcopy-gen -v=5 -h boilerplate.go.txt -i github.com/manifoldco/kubernetes-credentials/primitives -O zz_generated
 
@@ -58,13 +60,15 @@ docker:
 test: vendor
 	@CGO_ENABLED=0 go test -v ./...
 
+lint: $(LINTERS)
+
 METALINT=gometalinter --tests --disable-all --vendor --deadline=5m -e "zz_.*\.go" \
 	 ./... --enable
 
 $(LINTERS): vendor
 	$(METALINT) $@
 
-.PHONY: $(LINTERS) test
+.PHONY: $(LINTERS) test lint
 
 #################################################
 # Releasing

--- a/README.md
+++ b/README.md
@@ -80,27 +80,9 @@ credentials as secrets. We've [provided an example manifest file](_examples/secr
 
 ## Installation
 
-### Setting up the Manifold Auth Token to retrieve the credentials
-
-First, you'll need to create a new Auth Token:
-
-```
-$ manifold tokens create
-```
-
-Once you have the token, you'll want to create a new Kubernetes Secret:
-
-```
-$ kubectl create secret generic manifold-secrets --from-literal=api_token=<AUTH_TOKEN> --from-literal=team=<MANIFOLD_TEAM>
-```
-
-**Note:** The team value is optional. If a team is provided in the controller
-(see below), only resources that define this team will be picked up and used
-to load the credentials. If no team is defined, this is ignored.
-
 ### Setting up the controller
 
-Next, you'll need to set up the controller. The controller takes care of
+First, you'll need to set up the controller. The controller takes care of
 monitoring your Resource Definitions and populating the correct Kubernetes
 Secrets with Manifold Credentials. Without it, nothing will happen.
 
@@ -109,8 +91,27 @@ $ kubectl create -f https://raw.githubusercontent.com/manifoldco/kubernetes-cred
 ```
 
 **Note:** You can customise this credentials-controller file. This is a general
-purpose ReplicaSet. `K8S_NAMESPACE` and `MANIFOLD_AUTH_TOKEN` are required
-environment variables.
+purpose Deployment. `MANIFOLD_API_TOKEN` is a required environment variable for
+the controller.
+
+### Setting up the Manifold Auth Token to retrieve the credentials
+
+Once the controller is installed, you'll also want to enable access to the
+Manifold API. First, you'll need to create a new Auth Token:
+
+```
+$ manifold tokens create
+```
+
+Once you have the token, you'll want to create a new Kubernetes Secret:
+
+```
+$ kubectl create --namespace=manifold-system secret generic manifold-api-secrets --from-literal=api_token=<AUTH_TOKEN> --from-literal=team=<MANIFOLD_TEAM>
+```
+
+**Note:** The team value is optional. If a team is provided in the controller
+(see below), only resources that define this team will be picked up and used
+to load the credentials. If no team is defined, this is ignored.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ the new value.
 By using exsiting Kubernetes secrets, we allow you to use the Manifold
 credentials as secrets. We've [provided an example manifest file](_examples/secrets-usage/manifest.yml).
 
+### Defining secret types
+
+Kubernetes allows you to set up different types of secrets, such as Opaque,
+Docker Registry, TLS, ….
+
+The Manifold CRD allows you to create Opaque and Docker Registry types. The
+Opaque type is the default and is transparant, meaning that all credentials
+that are available through your custom resource will be loaded as a secret.
+
+#### Docker Registry
+
+Using the Docker Registry type it's possible to create a secret which will make
+it possible to pull images from a private registry. This secret type requires
+you to have the following credentials available:
+
+- `DOCKER_USERNAME`
+- `DOCKER_EMAIL`
+- `DOCKER_PASSWORD`
+
+There is the optional `DOCKER_SERVER` if your registry is anything other than
+Docker Hub.
+
+We've provided [an example](_examples/docker-registry/manifest.yml) on how to use the `docker-registry` secret type.
+
 ## Installation
 
 ### Setting up the controller

--- a/_examples/docker-registry/manifest.yml
+++ b/_examples/docker-registry/manifest.yml
@@ -1,0 +1,27 @@
+apiVersion: manifold.co/v1
+kind: Project
+metadata:
+  name: manifold-docker-registry
+spec:
+  project: manifold-terraform
+  type: docker-registry
+  resources:
+    - resource: docker
+
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: private-application
+spec:
+  template:
+    spec:
+      # by providing this, we tell kubernetes to use the previously generated
+      # secrets to authenticate with our registry.
+      imagePullSecrets:
+      - name: manifold-docker-registry
+      containers:
+      - image: manifoldco/private-application
+        name: private-application
+status: {}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -116,7 +116,7 @@ func (c *Controller) createOrUpdateProject(obj interface{}) {
 
 func (c *Controller) onProjectDelete(obj interface{}) {
 	project := obj.(*primitives.Project)
-	c.kc.Core().Secrets(project.Namespace).Delete(project.Name+"-credentials", &metav1.DeleteOptions{})
+	c.kc.Core().Secrets(project.Namespace).Delete(project.Name, &metav1.DeleteOptions{})
 }
 
 func (c *Controller) onResourceAdd(obj interface{})         { c.createOrUpdateResource(obj) }
@@ -147,13 +147,13 @@ func (c *Controller) createOrUpdateResource(obj interface{}) {
 }
 func (c *Controller) onResourceDelete(obj interface{}) {
 	resource := obj.(*primitives.Resource)
-	c.kc.Core().Secrets(resource.Namespace).Delete(resource.Name+"-credentials", &metav1.DeleteOptions{})
+	c.kc.Core().Secrets(resource.Namespace).Delete(resource.Name, &metav1.DeleteOptions{})
 }
 
 func (c *Controller) createOrUpdateSecret(meta *metav1.ObjectMeta, secrets map[string][]byte, gkv schema.GroupVersionKind) {
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      meta.Name + "-credentials",
+			Name:      meta.Name,
 			Namespace: meta.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(meta, gkv),

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -1,0 +1,150 @@
+package controller
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/api/core/v1"
+)
+
+func secretData(secrets map[string][]byte, secretType v1.SecretType) (map[string][]byte, error) {
+	switch secretType {
+	case v1.SecretTypeOpaque:
+		return secrets, nil
+	case v1.SecretTypeDockercfg:
+		dockercfg, err := dockerCfg(secrets)
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string][]byte{
+			v1.DockerConfigKey: dockercfg,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Secret type '%s' is not supported", string(secretType))
+	}
+}
+
+const dockerV1Server = "https://index.docker.io/v1/"
+
+// These types represent the docker configuration blocks. See
+// https://github.com/kubernetes/kubernetes/blob/84f03ef9572dc6307982d37b78b77621ffa10e37/pkg/credentialprovider/config.go#L33
+// for more information.
+// This is copied over so we don't have to initialize everything which gets
+// initialized in the credentialprovider package.
+type (
+	dockerConfig      map[string]dockerConfigEntry
+	dockerConfigEntry struct {
+		Username string
+		Password string
+		Email    string
+	}
+	dockerConfigEntryWithAuth struct {
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+		Email    string `json:"email,omitempty"`
+		Auth     string `json:"auth,omitempty"`
+	}
+)
+
+func dockerCfg(secrets map[string][]byte) ([]byte, error) {
+	server, err := dockerKey(secrets, "server", false)
+	if err != nil {
+		return nil, err
+	}
+	if server == "" {
+		server = dockerV1Server
+	}
+	username, err := dockerKey(secrets, "username", true)
+	if err != nil {
+		return nil, err
+	}
+	password, err := dockerKey(secrets, "password", true)
+	if err != nil {
+		return nil, err
+	}
+	email, err := dockerKey(secrets, "email", true)
+	if err != nil {
+		return nil, err
+	}
+
+	dockercfgAuth := dockerConfigEntry{
+		Username: username,
+		Password: password,
+		Email:    email,
+	}
+
+	dockerCfg := dockerConfig{
+		server: dockercfgAuth,
+	}
+
+	return json.Marshal(dockerCfg)
+}
+
+func dockerKey(secrets map[string][]byte, key string, required bool) (string, error) {
+	dockerKey := fmt.Sprintf("DOCKER_%s", strings.ToUpper(key))
+	value, ok := secrets[dockerKey]
+	if required && !ok {
+		return "", fmt.Errorf("Expected %s to be set", dockerKey)
+	}
+
+	return string(value), nil
+}
+
+func (ident *dockerConfigEntry) UnmarshalJSON(data []byte) error {
+	var tmp dockerConfigEntryWithAuth
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	ident.Username = tmp.Username
+	ident.Password = tmp.Password
+	ident.Email = tmp.Email
+
+	if len(tmp.Auth) == 0 {
+		return nil
+	}
+
+	ident.Username, ident.Password, err = decodeDockerConfigFieldAuth(tmp.Auth)
+	return err
+}
+
+func (ident dockerConfigEntry) MarshalJSON() ([]byte, error) {
+	toEncode := dockerConfigEntryWithAuth{
+		Username: ident.Username,
+		Password: ident.Password,
+		Email:    ident.Email,
+		Auth:     "",
+	}
+	toEncode.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)
+
+	return json.Marshal(toEncode)
+}
+
+// decodeDockerConfigFieldAuth deserializes the "auth" field from dockercfg into a
+// username and a password. The format of the auth field is base64(<username>:<password>).
+func decodeDockerConfigFieldAuth(field string) (username, password string, err error) {
+	decoded, err := base64.StdEncoding.DecodeString(field)
+	if err != nil {
+		return
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("unable to parse auth field")
+		return
+	}
+
+	username = parts[0]
+	password = parts[1]
+
+	return
+}
+
+func encodeDockerConfigFieldAuth(username, password string) string {
+	fieldValue := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(fieldValue))
+}

--- a/controller/utils_test.go
+++ b/controller/utils_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestSecretData(t *testing.T) {
+	t.Run("with an opaque type", func(t *testing.T) {
+		data := map[string][]byte{
+			"key": []byte("value"),
+		}
+
+		sData, err := secretData(data, v1.SecretTypeOpaque)
+		if err != nil {
+			t.Errorf("Expected no error, got '%s'", err)
+			t.FailNow()
+		}
+		if v := string(sData["key"]); v != "value" {
+			t.Errorf("Expected value to be 'value', got '%s'", v)
+		}
+	})
+
+	t.Run("with a docker registry type", func(t *testing.T) {
+		t.Run("with a valid set of credentials", func(t *testing.T) {
+			data := map[string][]byte{
+				"DOCKER_USERNAME": []byte("username"),
+				"DOCKER_PASSWORD": []byte("password"),
+				"DOCKER_EMAIL":    []byte("email"),
+				"DOCKER_SERVER":   []byte("my-server"),
+			}
+
+			dData, err := secretData(data, v1.SecretTypeDockercfg)
+			if err != nil {
+				t.Errorf("Expected no error, got '%s'", err)
+				t.FailNow()
+			}
+
+			var config dockerConfig
+			if err := json.Unmarshal(dData[v1.DockerConfigKey], &config); err != nil {
+				t.Errorf("Expected no error unmarshalling the docker config, got '%s'", err)
+				t.FailNow()
+			}
+
+			auth, ok := config["my-server"]
+			if !ok {
+				t.Errorf("Expected server auth to be set, not found")
+				t.FailNow()
+			}
+
+			if auth.Username != "username" {
+				t.Errorf("Expected username to be 'username', got '%s'", auth.Username)
+			}
+			if auth.Password != "password" {
+				t.Errorf("Expected password to be 'password', got '%s'", auth.Password)
+			}
+			if auth.Email != "email" {
+				t.Errorf("Expected email to be 'email', got '%s'", auth.Email)
+			}
+		})
+
+		t.Run("with an invalid set of credentials", func(t *testing.T) {
+			data := map[string][]byte{
+				"DOCKER_USERNAME": []byte("username"),
+				"DOCKER_PASSWORD": []byte("password"),
+				"DOCKER_EMAIL":    []byte("email"),
+				"DOCKER_SERVER":   []byte("my-server"),
+			}
+
+			required := []string{"DOCKER_USERNAME", "DOCKER_PASSWORD", "DOCKER_EMAIL"}
+			for _, skip := range required {
+				t.Run("missing "+skip, func(t *testing.T) {
+					skippedData := map[string][]byte{}
+					for k, v := range data {
+						if k == skip {
+							continue
+						}
+						skippedData[k] = v
+					}
+
+					if _, err := secretData(skippedData, v1.SecretTypeDockercfg); err == nil {
+						t.Errorf("Expected error, got none")
+					}
+				})
+			}
+		})
+	})
+
+	t.Run("with a non-supported type", func(t *testing.T) {
+		data := map[string][]byte{
+			"key": []byte("value"),
+		}
+
+		_, err := secretData(data, v1.SecretTypeServiceAccountToken)
+		if err == nil {
+			t.Errorf("Expected no error, got none")
+		}
+	})
+}

--- a/credentials-controller.yml
+++ b/credentials-controller.yml
@@ -1,7 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: manifold-system
+
+---
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: manifold-k8s-credentials-controller
+  name: credentials-controller
+  namespace: manifold-system
 spec:
   replicas: 1
   template:
@@ -10,22 +18,18 @@ spec:
         app: "manifold-k8s-credentials-controller"
     spec:
       containers:
-        - name: manifold-k8s-credentials-controller
+        - name: credentials-controller
           image: manifoldco/kubernetes-credentials:v0.0.4
           env:
-            - name: K8S_NAMESPACE # required to talk to the Kubernetes API.
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: MANIFOLD_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: manifold-secrets
+                  name: manifold-api-secrets
                   key: api_token
             - name: MANIFOLD_TEAM
               valueFrom:
                 secretKeyRef:
-                  name: manifold-secrets
+                  name: manifold-api-secrets
                   key: team
           resources:
             requests:

--- a/credentials-controller.yml
+++ b/credentials-controller.yml
@@ -31,6 +31,7 @@ spec:
                 secretKeyRef:
                   name: manifold-api-secrets
                   key: team
+                  optional: true
           resources:
             requests:
               cpu: 100m

--- a/primitives/project.go
+++ b/primitives/project.go
@@ -2,6 +2,7 @@ package primitives
 
 import (
 	"github.com/manifoldco/go-manifold/integrations/primitives"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,7 +28,20 @@ type ProjectList struct {
 type ProjectSpec struct {
 	Name      string          `json:"project,name"`
 	Team      string          `json:"team,omitempty"`
+	Type      string          `json:"type,omitempty"`
 	Resources []*ResourceSpec `json:"resources,omitempty"`
+}
+
+// SecretType returns the type of secret that should be generated for this spec.
+func (ps *ProjectSpec) SecretType() v1.SecretType {
+	t, err := secretType(ps.Type)
+
+	// TODO jelmer: once we've put in validation, we can ignore this error.
+	if err != nil {
+		panic(err)
+	}
+
+	return t
 }
 
 // ManifoldPrimitive converts the ProjectSpec to a manifold project integration

--- a/primitives/resource.go
+++ b/primitives/resource.go
@@ -2,6 +2,7 @@ package primitives
 
 import (
 	"github.com/manifoldco/go-manifold/integrations/primitives"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,7 +28,20 @@ type ResourceList struct {
 type ResourceSpec struct {
 	Name        string            `json:"resource,name"`
 	Team        string            `json:"team,omitempty"`
+	Type        string            `json:"type,omitempty"`
 	Credentials []*CredentialSpec `json:"credentials,omitempty"`
+}
+
+// SecretType returns the type of secret that should be generated for this spec.
+func (rs *ResourceSpec) SecretType() v1.SecretType {
+	t, err := secretType(rs.Type)
+
+	// TODO jelmer: once we've put in validation, we can ignore this error.
+	if err != nil {
+		panic(err)
+	}
+
+	return t
 }
 
 // ManifoldPrimitive converts the ResourceSpec to a manifold project integration

--- a/primitives/utils.go
+++ b/primitives/utils.go
@@ -1,0 +1,19 @@
+package primitives
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+func secretType(t string) (v1.SecretType, error) {
+	switch t {
+	case "opaque":
+	case "":
+		return v1.SecretTypeOpaque, nil
+	case "docker-registry":
+		return v1.SecretTypeDockercfg, nil
+	default:
+		return "", fmt.Errorf("Secret type '%s' not supported", t)
+	}
+}

--- a/primitives/utils.go
+++ b/primitives/utils.go
@@ -13,7 +13,7 @@ func secretType(t string) (v1.SecretType, error) {
 		return v1.SecretTypeOpaque, nil
 	case "docker-registry":
 		return v1.SecretTypeDockercfg, nil
-	default:
-		return "", fmt.Errorf("Secret type '%s' not supported", t)
 	}
+
+	return "", fmt.Errorf("Secret type '%s' not supported", t)
 }

--- a/primitives/zz_generated.go
+++ b/primitives/zz_generated.go
@@ -3,7 +3,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) 2017, Arigato Machine Inc.
+Copyright (c) 2018, Arigato Machine Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This enforces the controller to run in it's own namespace. This separates
the Manifold specific resources from the users resources (if the user uses
our pre-built controller definitions).

This ensures that if a user deletes a specific namespace, secrets defined
in another namespace aren't affected by this deletion.

This also removes the `-credentials` suffix from the secrets. The users
should themselves desided what the name of the secret should be. This
shouldn't be altered by the controller.