### PR TITLE
Better error msg when credential fails

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -94,7 +94,7 @@ func (c *Controller) createOrUpdateProject(obj interface{}) {
 
 	creds, err := c.mc.GetResourcesCredentialValues(ctx, &project.Spec.Name, project.Spec.ManifoldPrimitive().Resources)
 	if err != nil {
-		log.Print("Error getting the credentials:", err)
+		log.Printf("Error getting the credentials for %s: %s", project.Spec, err)
 		return
 	}
 

--- a/primitives/project.go
+++ b/primitives/project.go
@@ -1,6 +1,8 @@
 package primitives
 
 import (
+	"strings"
+
 	"github.com/manifoldco/go-manifold/integrations/primitives"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,4 +59,23 @@ func (ps *ProjectSpec) ManifoldPrimitive() *primitives.Project {
 		Team:      ps.Team,
 		Resources: resources,
 	}
+}
+
+// String returns a string representation of the spec
+func (ps *ProjectSpec) String() string {
+	var result []string
+
+	if ps.Name != "" {
+		result = append(result, "project: "+ps.Name)
+	}
+
+	if ps.Team != "" {
+		result = append(result, "team: "+ps.Team)
+	}
+
+	if ps.Type != "" {
+		result = append(result, "type: "+ps.Type)
+	}
+
+	return strings.Join(result, ", ")
 }

--- a/primitives/project_test.go
+++ b/primitives/project_test.go
@@ -1,0 +1,57 @@
+package primitives
+
+import "testing"
+
+func TestProjectSpec_String(t *testing.T) {
+
+	tcs := []struct {
+		scenario string
+		spec     ProjectSpec
+		result   string
+	}{
+		{
+			scenario: "empty",
+			result:   "",
+		},
+		{
+			scenario: "with name",
+			spec: ProjectSpec{
+				Name: "production",
+			},
+			result: "project: production",
+		},
+		{
+			scenario: "with team",
+			spec: ProjectSpec{
+				Team: "manifold",
+			},
+			result: "team: manifold",
+		},
+		{
+			scenario: "with type",
+			spec: ProjectSpec{
+				Type: "docker-registry",
+			},
+			result: "type: docker-registry",
+		},
+		{
+			scenario: "with all fields",
+			spec: ProjectSpec{
+				Name: "production",
+				Team: "manifold",
+				Type: "docker-registry",
+			},
+			result: "project: production, team: manifold, type: docker-registry",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.scenario, func(t *testing.T) {
+			got := tc.spec.String()
+
+			if got != tc.result {
+				t.Fatalf("expected project spec string to eq %q, got %q", tc.result, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Give more context for the log.

From:

```
Error getting the credentials:project with the given label is not found
```

To:

```
Error getting the credentials for project: prod, team: manifold: project with the given label is not found
```