### PR TITLE
added note about defining rbac clusterRole on GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ the controller.
 To use RBAC, we'll add additional ClusterRoles to allow managing CRDs and
 secrets.
 
+**Note:** If you are using Google Kubernetes Engine (GKE) you may need to give
+yourself additional privileges to create the ClusterRole defined in `rbac.yaml`
+
+```
+kubectl create clusterrolebinding your-user-cluster-admin-binding --clusterrole=cluster-admin --user=your.google.cloud.email@example.org
+```
+
+Defining the `ClusterRole`:
 ```
 $ kubectl create -f https://raw.githubusercontent.com/manifoldco/kubernetes-credentials/master/rbac.yml
 ```


### PR DESCRIPTION
This was failing that manifold:credentials didn't have sufficient
privileges before this.

Another change I was considering making but figured I would ask if it would actually be accepted first:

I think you should consider removing the namespace definition in https://github.com/manifoldco/kubernetes-credentials/blob/master/credentials-controller.yml#L1.  

The readme has you create the namespace before before using that file.  I had to delete that definition several times so if I was using the file to do that I had recreate my secrets.